### PR TITLE
feat: Phase 2 スクレイパー4モジュールの実装・動作検証

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # Data output
 data/*.json
 data/*.csv
+data/*.db
 
 # OS
 .DS_Store

--- a/demo_site/app.py
+++ b/demo_site/app.py
@@ -9,7 +9,7 @@ import io
 import json
 import os
 
-from flask import Flask, Response, jsonify, redirect, render_template, session
+from flask import Flask, Response, jsonify, redirect, render_template, request, session
 
 app = Flask(__name__)
 app.secret_key = "scrapling-demo-secret-key"
@@ -24,7 +24,12 @@ def load_products() -> list[dict]:
 
 @app.route("/")
 def index():
-    version = session.get("version", "v1")
+    # クエリパラメータ ?v=v1 or ?v=v2 でバージョン指定（スクレイパーから使用）
+    v = request.args.get("v")
+    if v in ("v1", "v2"):
+        version = v
+    else:
+        version = session.get("version", "v1")
     products = load_products()
     return render_template(f"{version}.html", products=products)
 
@@ -57,6 +62,10 @@ def api_products():
 
 @app.route("/version")
 def version():
+    # クエリパラメータ ?v= があればそれを返す（スクレイパーから使用）
+    v = request.args.get("v")
+    if v in ("v1", "v2"):
+        return jsonify({"version": v})
     return jsonify({"version": session.get("version", "v1")})
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scrapling>=0.4
+scrapling[all]>=0.4
 flask>=3.0
 beautifulsoup4>=4.12
 streamlit>=1.40

--- a/scraper/comparison.py
+++ b/scraper/comparison.py
@@ -62,13 +62,12 @@ def main():
     results = compare()
 
     # 表形式で出力
-    header = f"{'セレクタ':<22} {'BS4':>6} {'Scrapling':>10} {'一致':>6}"
-    print(header)
-    print("-" * len(header))
+    print(f"{'セレクタ':<20} {'BS4':>6} {'Scrapling':>10} {'一致':>6}")
+    print("-" * 46)
 
     for css, counts in results.items():
         match = "✅" if counts["bs4"] == counts["scrapling"] else "⚠️"
-        print(f"{css:<22} {counts['bs4']:>6} {counts['scrapling']:>10} {match:>6}")
+        print(f"{css:<20} {counts['bs4']:>6} {counts['scrapling']:>10} {match:>6}")
 
     # サマリ
     total_bs4 = sum(c["bs4"] for c in results.values())

--- a/scraper/similarity.py
+++ b/scraper/similarity.py
@@ -16,7 +16,7 @@ def demo_find_similar(url: str = BASE_URL):
     page = Fetcher.get(url)
 
     # v1/v2 どちらでも対応
-    first_card = page.css_first(".product-card") or page.css_first(".item-tile")
+    first_card = page.css(".product-card").first or page.css(".item-tile").first
     if not first_card:
         print("商品カードが見つかりませんでした")
         return []
@@ -29,8 +29,7 @@ def demo_find_similar(url: str = BASE_URL):
     print(f"find_similar() で発見: {len(similar)}件")
 
     for i, el in enumerate(similar, 1):
-        # 商品名を探す
-        name_el = el.css_first("h2, h3")
+        name_el = el.css("h2, h3").first
         name = name_el.text.strip() if name_el else "(名前不明)"
         print(f"  {i}. {name}")
 
@@ -45,7 +44,10 @@ def demo_find_by_text(url: str = BASE_URL):
 
     print(f"\nテキスト検索デモ:")
     for term in search_terms:
-        results = page.find_by_text(term)
+        # partial=True で部分一致、first_match=False で全件取得
+        results = page.find_by_text(term, first_match=False, partial=True)
+        if results is None:
+            results = []
         print(f"  「{term}」→ {len(results)}件ヒット")
         for el in results[:3]:
             print(f"    <{el.tag} class=\"{el.attrib.get('class', '')}\"> {el.text.strip()[:50]}")
@@ -56,7 +58,7 @@ def demo_css_selector_generation(url: str = BASE_URL):
     page = Fetcher.get(url)
 
     # 最初の商品名要素を取得
-    name_el = page.css_first(".product-name") or page.css_first(".title")
+    name_el = page.css(".product-name").first or page.css(".title").first
     if not name_el:
         print("\n商品名要素が見つかりませんでした")
         return
@@ -64,8 +66,13 @@ def demo_css_selector_generation(url: str = BASE_URL):
     print(f"\nCSS セレクタ自動生成デモ:")
     print(f"  対象要素: <{name_el.tag} class=\"{name_el.attrib.get('class', '')}\"> 「{name_el.text.strip()}」")
 
+    # generate_css_selector はプロパティ
     generated = name_el.generate_css_selector
     print(f"  生成されたセレクタ: {generated}")
+
+    # フルパスセレクタも生成
+    full_generated = name_el.generate_full_css_selector
+    print(f"  フルパスセレクタ: {full_generated}")
 
 
 def main():


### PR DESCRIPTION
## Summary
- **basic.py**: Scrapling Fetcherでv1/v2フォールバック対応。全6フィールド（name, price, category, rating, reviews, description）を正しく抽出
- **adaptive.py**: Adaptive機能の正しいAPI使用（auto_save/adaptive）。`?v=`パラメータでバージョン制御、ストレージクリア対応
- **comparison.py**: BS4 vs Scrapling の比較表を表形式で出力
- **similarity.py**: find_similar / find_by_text / generate_css_selector の3機能デモ
- **demo_site/app.py**: `?v=v1`/`?v=v2`クエリパラメータ対応追加（スクレイパーからのバージョン指定）
- **requirements.txt**: `scrapling[all]`に変更（Fetcher依存のcurl_cffi/playwright/browserforge解決）

## Test plan
- [x] `python -m scraper.basic` → 6件取得、`data/products_v1.json`生成
- [x] `python -m scraper.adaptive full` → BS4 0/5件 vs Scrapling 5/5件復元、`data/adaptive_result.json`生成
- [x] `python -m scraper.adaptive phase1` → v1指紋保存
- [x] `python -m scraper.adaptive phase2` → v2 Adaptive復元
- [x] `python -m scraper.comparison` → BS4=36 Scrapling=36（v1で一致）
- [x] `python -m scraper.similarity` → find_similar 5件、find_by_text 3語テスト、セレクタ自動生成

Closes #3

Generated with Claude Code